### PR TITLE
fix worker path

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.2",
+  "version": "0.2.3",
   "name": "Kindle Cloud Reader Translate",
   "short_name": "KCR Translate",
   "manifest_version": 2,

--- a/chrome/ocr.js
+++ b/chrome/ocr.js
@@ -6,6 +6,7 @@
     worker = Tesseract.createWorker({
       workerPath: chrome.runtime.getURL("lib/tesseract/worker.min.js"),
       corePath: chrome.runtime.getURL("lib/tesseract/tesseract-core.wasm.js"),
+      workerBlobURL: false,
       logger: (m) => {
         console.info("tesseract progress:", m);
         if (m.status === "recognizing text") {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcr-translate-ext",
-  "version": "0.1.2",
+  "version": "0.2.3",
   "description": "Kindle Cloud Reader Translate",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
I have an issue with the latest chrome (v.94). Downloading worker script using `blob` and local `worker.js` path is not working anymore:
> Refused to load the script 'chrome-extension://ipalacjfeejceeogpnfaijpadginmfhk/lib/tesseract/worker.min.js' because it violates the following Content Security Policy directive: "script-src 'self' blob: filesystem:". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback.

> Uncaught DOMException: Failed to execute 'importScripts' on 'WorkerGlobalScope': The script at 'chrome-extension://ipalacjfeejceeogpnfaijpadginmfhk/lib/tesseract/worker.min.js' failed to load.
    at blob:chrome-extension://ipalacjfeejceeogpnfaijpadginmfhk/874347fc-6004-42d8-9d0c-bc54ccecb046:1:1
  
Related tesseract sources:
- https://github.com/naptha/tesseract.js/blob/master/src/worker/browser/spawnWorker.js
- https://github.com/naptha/tesseract.js/blob/master/docs/api.md#create-worker