### PR TITLE
update eslint settings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,16 @@
 {
   "root": true,
-  "extends": ["eslint:recommended"],
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended", "plugin:prettier/recommended"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": { "project": ["./tsconfig.json"] },
-  "plugins": ["@typescript-eslint", "prettier"],
-  "ignorePatterns": ["dist/**", "cypress/**", "webpack.*.js"]
+  "plugins": ["@typescript-eslint"],
+  "ignorePatterns": ["dist/**", "cypress/**", "webpack.*.js"],
+  "env": {
+    "browser": true,
+    "node": true,
+    "webextensions": true
+  },
+  "rules": {
+    "prettier/prettier": "warn"
+  }
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 dist/
+node_modules/

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "noEmit": false,
-    "jsx": "react"
+    "jsx": "react-jsx"
   },
   "include": ["chrome"],
   "exclude": ["dist", "node_modules"]


### PR DESCRIPTION
- fix for `typescript`
- support globals (e.g. `document`, `chrome`, `window`)
- display `prettier` issues as a warnings