### PR TITLE
fix selection translation 0.3.3

### DIFF
--- a/chrome/background/ocr.ts
+++ b/chrome/background/ocr.ts
@@ -1,3 +1,4 @@
+import { restoreDefaultSettings } from "./../../cypress/plugins/puppeteer";
 import Tesseract, { Worker } from "tesseract.js";
 import { IDimensions, IOcrOutputData } from "../const";
 
@@ -26,6 +27,15 @@ export const doOCR = async (
   columns: IDimensions[]
 ): Promise<IOcrOutputData> => {
   const values = [];
+  if (!columns?.length) {
+    const { data } = await worker.recognize(base64);
+    const result = data.text;
+    if (data.confidence > 0.6) {
+      return { text: result.replaceAll(/(?:\r\n|\r|\n)/g, " "), error: "" };
+    } else {
+      return { error: "Not enough confidence", text: "" };
+    }
+  }
   for (let i = 0; i < columns.length; i++) {
     const { data } = await worker.recognize(base64, {
       rectangle: columns[i],

--- a/chrome/content/kindle/KCRListener/KindleCloudReaderListener.tsx
+++ b/chrome/content/kindle/KCRListener/KindleCloudReaderListener.tsx
@@ -20,6 +20,7 @@ export const KindleCloudReaderListener: React.FC<IKindleCloudReaderListenerProps
   const setFullPageTranslationMode = useCallback((enabled: boolean) => {
     dispatch(actionCreators.setFullPageTranslationMode(enabled));
   }, []);
+  console.log("state", state);
   const onLocationChange = useCallback(() => {
     if (state.isFullPageTranslationMode) {
       // if we in full page translation mode,
@@ -33,6 +34,7 @@ export const KindleCloudReaderListener: React.FC<IKindleCloudReaderListenerProps
   }, [state.isFullPageTranslationMode]);
   const onDoubleClick = useCallback(
     (e: MouseEvent) => {
+      console.debug("double click");
       const target = e.target as HTMLSpanElement | null;
       if (state.isFullPageTranslationMode || !target) {
         return;
@@ -61,6 +63,7 @@ export const KindleCloudReaderListener: React.FC<IKindleCloudReaderListenerProps
       // find all selected areas
       // they will exist in dnd selection and will be empty in double click selection
       const selectedAreas = getAllSelectedTexts(kindleElements);
+      console.debug("selectedAreas: ", selectedAreas);
       if (selectedAreas.length === 0) {
         return;
       }

--- a/chrome/content/kindle/OCR.tsx
+++ b/chrome/content/kindle/OCR.tsx
@@ -62,6 +62,7 @@ export const OCR: React.FC = () => {
       if (data) {
         recognizeText(messagingService, data)
           .then(({ error, text }) => {
+            console.log("recognition error:", error);
             setError(error);
             onTranslationFinish(text);
           })

--- a/chrome/content/kindle/kindle.tsx
+++ b/chrome/content/kindle/kindle.tsx
@@ -13,6 +13,7 @@ const createListenerComponent = async (
   const messagingService = new Messaging();
   console.log("translateengines: ", settings.translateEngines);
   const kindleElements = await waitForKindleCenter();
+  // console.log(kindleElements);
   const ListenerWrapper: React.FC = ({ children }) => {
     if (!settings.translationEnabled) {
       console.info("Translation is disabled");
@@ -32,6 +33,7 @@ const createListenerComponent = async (
 };
 
 const KindleContentScript = () => {
+  // console.debug("KindleContentScript");
   const settingsService = new Settings();
   const Wrapper = React.lazy(() => createListenerComponent(settingsService));
   return (

--- a/chrome/content/kindle/utils.ts
+++ b/chrome/content/kindle/utils.ts
@@ -4,7 +4,7 @@ import { IDimensions } from "../../const";
 const kindleIframeId = "KindleReaderIFrame";
 const kindleContentAreaId = "kindleReader_content";
 const kindleTextClass = "kg-client-dictionary";
-const kindleTextSelectionClass = "kg-client-selection";
+const kindleTextSelectionClass = "kg-selection";
 export const detectedTextContainerId = "kcr-selection";
 
 export enum TranslationStatus {
@@ -23,11 +23,14 @@ export const waitForKindleCenter = async (): Promise<IKindleCenterElements> => {
   const kindleElementsGetter = (): IKindleCenterElements | null => {
     const kindleIframeDocument = document;
     const kindleContentArea: HTMLElement | null | undefined =
-      kindleIframeDocument?.getElementById(kindleContentAreaId);
+      kindleIframeDocument?.getElementById("kr-renderer")?.parentElement?.parentElement;
     const locationDataContainer: HTMLElement | null | undefined =
       kindleIframeDocument?.getElementById("kindleReader_locationPopup_labelDiv");
+    // console.debug("locationDataContainer", locationDataContainer);
+    // console.debug("kindleContenArea", kindleContentArea);
+    // console.debug("kindleIframe", kindleIframeDocument);
     if (!kindleContentArea || !locationDataContainer) {
-      return null;
+      console.error("KCR translate kindle objects not found: locationDataContainer, kindleContentArea ");
     }
     return {
       kindleIframeDocument: kindleIframeDocument!,
@@ -76,6 +79,7 @@ export function transformSelected(
       height: pageImage.clientHeight,
     };
   });
+  // console.debug("columns", columns);
 
   const region = new Path2D();
   selectedAreas.forEach((selection) => {
@@ -86,11 +90,13 @@ export function transformSelected(
       number,
       number
     ];
+    // console.debug("pixels", pixels);
     region.rect(...pixels);
   });
   ctx.clip(region);
   ctx.drawImage(pageImage, 0, 0, pageImage.clientWidth, pageImage.clientHeight);
   const dataUrl = canvas.toDataURL();
+  // console.debug(dataUrl);
   return {
     dataUrl,
     columns,

--- a/chrome/manifest/baseManifestV2.js
+++ b/chrome/manifest/baseManifestV2.js
@@ -1,7 +1,7 @@
 const commonManifest = require("./manifest.json");
 
 const makeUrl = (str) => `https://${str}/*`;
-const makeKindleUrl = (str) => `https://${str}/KindleReaderApp`; // kindle book iframe
+// const makeKindleUrl = (str) => `https://${str}/KindleReaderApp`; // kindle book iframe
 
 const kindleCloudReaderMatches = [
   "lesen.amazon.de",
@@ -41,7 +41,7 @@ module.exports = {
       run_at: "document_end",
     },
     {
-      matches: kindleCloudReaderMatches.map(makeKindleUrl),
+      matches: kindleCloudReaderMatches.map(makeUrl),
       js: ["index.js"],
       run_at: "document_end",
       all_frames: true, // allowed running extension for iframe

--- a/chrome/options/options.tsx
+++ b/chrome/options/options.tsx
@@ -1,10 +1,7 @@
 import React, { ChangeEventHandler, useEffect, useState } from "react";
 import { Engines, ITranslateEngine, tesseractLangs } from "../const";
 import { DictCCEngineOptions } from "./dict/options";
-import {
-  GoogleTranslateEngineOptions,
-  GoogleTranslateExtEngineOptions,
-} from "./google/options";
+import { GoogleTranslateEngineOptions, GoogleTranslateExtEngineOptions } from "./google/options";
 import { Settings } from "../services/settings";
 import { showMessage } from "./utils";
 
@@ -23,11 +20,7 @@ const EnginesSelect = ({
     onChangeEngine(event.target.value as Engines);
   };
   return (
-    <select
-      id="translate_engine"
-      onChange={onSelect}
-      value={selectedEngineName}
-    >
+    <select id="translate_engine" onChange={onSelect} value={selectedEngineName}>
       {translateEngines.map((engine) => (
         <option key={engine.name} value={engine.name}>
           {engine.label}
@@ -46,11 +39,9 @@ const Options = () => {
 
   const onTranslationToggle = () => {
     setTranslationEnabled(!isTranslationEnabled);
-    settingsServise
-      .setTranslationEnabled(!isTranslationEnabled)
-      .catch((error) => {
-        setTranslationEnabled(!isTranslationEnabled);
-      });
+    settingsServise.setTranslationEnabled(!isTranslationEnabled).catch((error) => {
+      setTranslationEnabled(!isTranslationEnabled);
+    });
   };
 
   const onChangeEngine = (engineName: Engines) => {
@@ -77,9 +68,7 @@ const Options = () => {
     setEngines(newEngines);
   };
 
-  const onOcrLanguageSelect: ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
+  const onOcrLanguageSelect: ChangeEventHandler<HTMLSelectElement> = (event) => {
     setOcrLangs(event.target.value);
   };
   const onSaveBtnClick = () => {
@@ -163,10 +152,7 @@ const Options = () => {
               selectedEngine={selectedEngine}
               onEngineUpdate={onEngineUpdate}
             />
-            <DictCCEngineOptions
-              selectedEngine={selectedEngine}
-              onEngineUpdate={onEngineUpdate}
-            />
+            <DictCCEngineOptions selectedEngine={selectedEngine} onEngineUpdate={onEngineUpdate} />
             <GoogleTranslateExtEngineOptions
               selectedEngine={selectedEngine}
               onEngineUpdate={onEngineUpdate}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcr-translate-ext",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Translate directly from Kindle Cloud Reader",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Amazon changed DOM structure again. Temporary fix for case when `columns` not found.
Split columns translation, when selected region starts in first column and end in second column, would not work after this temporary fix. 
@p-mazhnik if you can take a look please, i hope it doesn't break full page translations